### PR TITLE
MetaInitiative integration complete for MetaRoll & MetaEvaluate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ### Latest Changes
 These are the latest changes for the Official Metanthropes RPG System for Foundry VTT
 #### 0.7.00 - Current (status)
+- XP System: Metapowers (pushed to v0.8)
 - Foundry core version 11 support (done)
 - New Player Experience: Movement Automations (done)
-- XP System: Metapowers (pending)
-- New Actor / Token logic to support non-linked Actors (testing)
-- Added official system support for Terrain Ruler, Enhanced Terrain Layer and DF Chat Enhancements (done)
-- New MetaEvaluate Function (done)
+- New Player Experience: Tooltips for the majority of the Overview Sheet (done)
+- New Actor / Token logic to support non-linked Actors (done)
+- Added official system support for Terrain Ruler, Enhanced Terrain Layer, Combat Carousel (PR pending) and DF Chat Enhancements (done)
+- New MetaEvaluate Function for Stat Rolls and Initiative (done)
 #### 0.6.00 - 0.6.10
 - New Player Experience: New Character sheet for protagonists with better UI and UX
 - New Player Experience: New Actor Creation workflow with automations and drop-down menus

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -3,12 +3,12 @@
 //?import MetaInitiative for combat
 import { MetaInitiative } from "../helpers/metainitiative.mjs";
 export class MetanthropesActor extends Actor {
-	// Setting default Token configuration for all actors
+	//? Setting default Token configuration for all actors
 	async _preCreate(data, options, user) {
 		await super._preCreate(data, options, user);
 		let createData = {};
 		let defaultToken = game.settings.get("core", "defaultToken");
-		// Configure Display Bars & Name Visibility
+		//? Configure Display Bars & Name Visibility
 		if (!data.prototypeToken)
 			mergeObject(createData, {
 				"prototypeToken.bar1": { attribute: "Vital.Destiny" },
@@ -114,7 +114,7 @@ export class MetanthropesActor extends Actor {
 		let statExperienceSpent = 0;
 		let advancementCount = 0;
 		let charzerofullpenalty = 0;
-		console.log("Metanthropes RPG System | Actor Prep | Updating Characteristics & Stats for", this.type, "-", this.name);
+		console.log("Metanthropes RPG System | Actor Prep | Updating Characteristics & Stats for", this.type+":", this.name);
 		for (const [CharKey, CharValue] of Object.entries(systemData.Characteristics)) {
 			//? reset charzerofullpenalty to 0
 			charzerofullpenalty = 0;
@@ -228,7 +228,7 @@ export class MetanthropesActor extends Actor {
 		let advancementCount = 0;
 		let perkExperienceSpent = 0;
 		// console.log("Metanthropes RPG System | ====================================");
-		console.log("Metanthropes RPG System | Actor Prep | Updating Perks for", this.type, "-", this.name);
+		console.log("Metanthropes RPG System | Actor Prep | Updating Perks for", this.type+":", this.name);
 		//	console.log("Experience Spent before Perks:", experienceAlreadySpent);
 		//? Calculate the experience spent on Knowledge Perks
 		for (const [KnowPerkKey, KnowPerkValue] of Object.entries(systemData.Perks.Knowledge)) {
@@ -292,8 +292,7 @@ export class MetanthropesActor extends Actor {
 	}
 	async _prepareDerivedMovementData(actorData) {
 		const systemData = actorData.system;
-		//console.log("Metanthropes RPG System | ====================================");
-		console.log("Metanthropes RPG System | Actor Prep | Updating Movement for", this.type, "-", this.name);
+		console.log("Metanthropes RPG System | Actor Prep | Updating Movement for", this.type+":", this.name);
 		//*first we will calculate the current values from buffs and conditions, then we take their modifiers and calculate the movement value
 		let speedinitial = Number(systemData.physical.speed.initial);
 		let weightinitial = Number(systemData.physical.weight.initial);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -47,15 +47,14 @@ export class MetanthropesActor extends Actor {
 		}
 		//? Fix for Token Attacher / CF Import - from wh4e
 		if (!createData.prototypeToken) createData.prototypeToken = {};
-		//? Link Actor data and enable vision only for Protagonists
+		//? Enable vision for all actors except vehicles
 		if (data.type !== "Vehicle") {
 			createData.prototypeToken.sight = { enabled: true };
-			//! Adding this here so all actors have prototypeToken.actorLink = true until I figure out how to do it for tokens and not actors
+		}
+		//? Enable Linked Tockens for Protagonists and Metanthropes by default
+		if (data.type == "Protagonist" || data.type == "Metanthrope") {
 			createData.prototypeToken.actorLink = true;
 		}
-		//	if (data.type == "Protagonist") {
-		//		createData.prototypeToken.actorLink = true;
-		//	}
 		this.updateSource(createData);
 	}
 	/** @override */
@@ -81,6 +80,7 @@ export class MetanthropesActor extends Actor {
 			if (!this.primeimg || this.primeimg == "systems/metanthropes-system/artwork/.png") {
 				//? for Protagonists without a prime metapower defined, make it the metanthropes-logo
 				if (!this.system.entermeta.primemetapower.value) {
+					//! we need a new image file for this - right now will show up as a missing graphic error
 					this.primeimg = `systems/metanthropes-system/artwork/metapowers/Choose Prime Metapower.png`;
 				} else {
 					//? for Protagonists with a prime metapower defined, make it their respective metapower icon
@@ -116,16 +116,6 @@ export class MetanthropesActor extends Actor {
 		let charzerofullpenalty = 0;
 		console.log("Metanthropes RPG System | Actor Prep | Updating Characteristics & Stats for", this.type, "-", this.name);
 		for (const [CharKey, CharValue] of Object.entries(systemData.Characteristics)) {
-			//	console.log("Metanthropes RPG Calculating", CharKey, "Base: Initial + Progressed");
-			//	console.log(
-			//		CharKey,
-			//		"Base:",
-			//		CharValue.Base,
-			//		"Initial:",
-			//		CharValue.Initial,
-			//		"Progressed:",
-			//		CharValue.Progressed
-			//	);
 			//? reset charzerofullpenalty to 0
 			charzerofullpenalty = 0;
 			//? Calculate the advancement count based on the characteristic's progressed value
@@ -141,16 +131,6 @@ export class MetanthropesActor extends Actor {
 				console.log("Metanthropes RPG System | Actor Prep | Experience Spent to Progress", CharKey, "Characteristic:", characteristicExperienceSpent);
 			}
 			parseInt((CharValue.Base = Number(CharValue.Initial) + Number(Number(CharValue.Progressed) * 5)));
-			//	console.log("Metanthropes RPG New", CharKey, "Base:", CharValue.Base);
-			//	console.log("Metanthropes RPG Calculating", CharKey, "Buff:", CharValue.Buff.Name, CharValue.Buff.Current);
-			//	console.log(
-			//		"Metanthropes RPG Calculating",
-			//		CharKey,
-			//		"Condition:",
-			//		CharValue.Condition.Name,
-			//		CharValue.Condition.Current
-			//	);
-			//	console.log("Metanthropes RPG Calculating", CharKey, "Current: Base + Buff - Condition");
 			parseInt(
 				(CharValue.Current =
 					Number(CharValue.Base) +
@@ -161,22 +141,9 @@ export class MetanthropesActor extends Actor {
 				charzerofullpenalty = CharValue.Current;
 				CharValue.Current = 0;
 				//! decided not to spam everyone about this, however logging it to console
-				//ui.notifications.error(this.name + "'s " + CharKey + " has dropped to 0!");
 				console.log("Metanthropes RPG System | Actor Prep |", this.name+"'s", CharKey, "has dropped to 0!");
 			}
-			//	console.log("Metanthropes RPG New", CharKey, "Current:", CharValue.Current);
-			//	console.log("------------------------------------------------------------------------");
 			for (const [StatKey, StatValue] of Object.entries(CharValue.Stats)) {
-				//	console.log("Metanthropes RPG Calculating", StatKey, "Base: Initial + Progressed");
-				//	console.log(
-				//		StatKey,
-				//		"Base:",
-				//		StatValue.Base,
-				//		"Initial:",
-				//		StatValue.Initial,
-				//		"Progressed:",
-				//		StatValue.Progressed
-				//	);
 				//? Calculate the advancement count based on the characteristic's progressed value
 				advancementCount = Number(StatValue.Progressed);
 				//? Calculate the experience spent on this characteristic
@@ -189,77 +156,32 @@ export class MetanthropesActor extends Actor {
 				//? Add the experience spent on this characteristic to the total experience spent, only if Progressed is >0
 				if (advancementCount > 0) {
 					experienceSpent += statExperienceSpent;
-					//console.log("Experience Spent to Progress", StatKey, "Stat:", statExperienceSpent);
 				}
 				parseInt((StatValue.Base = Number(StatValue.Initial) + Number(Number(StatValue.Progressed) * 5)));
-				//console.log("Metanthropes RPG New", StatKey, "Base:", StatValue.Base);
-				//	console.log(
-				//		"Metanthropes RPG Calculating",
-				//		StatKey,
-				//		"Buff:",
-				//		StatValue.Buff.Name,
-				//		StatValue.Buff.Current
-				//	);
-				//	console.log(
-				//		"Metanthropes RPG Calculating",
-				//		StatKey,
-				//		"Condition:",
-				//		StatValue.Condition.Name,
-				//		StatValue.Condition.Current
-				//	);
-				// console.log("Metanthropes RPG Calculating", StatKey, "Current: Base + Buff - Condition");
 				parseInt(
 					(StatValue.Current =
 						Number(StatValue.Base) +
 						Number(Number(StatValue.Buff.Current) * 5) -
 						Number(Number(StatValue.Condition.Current) * 5))
 				);
-				// console.log("Metanthropes RPG New", StatKey, "Current:", StatValue.Current);
-				//	console.log(
-				//		"Metanthropes RPG Calculating",
-				//		StatKey,
-				//		"for Rolls:",
-				//		StatKey,
-				//		"Current +",
-				//		CharKey,
-				//		"Current"
-				//	);
 				parseInt(
 					(StatValue.Roll =
 						Number(StatValue.Current) + Number(CharValue.Current) + Number(charzerofullpenalty))
 				);
 				if (StatValue.Roll <= 0) {
 					StatValue.Roll = 0;
-					//ui.notifications.error(this.name + "'s " + StatKey + " has dropped to 0!");
 					//! decided not to spam everyone about this, however logging it to console
 					console.log("Metanthropes RPG System | Actor Prep |", this.name+"'s", StatKey, "has dropped to 0!");
-					// console.log("Metanthropes RPG", StatKey, "has dropped to 0!");
 				}
-				// console.log("Metanthropes RPG Final", StatKey, "for Rolls:", StatValue.Roll);
-				//	console.log(
-				//		"============================================================================================="
-				//	);
 			}
 		}
-		//	console.log("Metanthropes RPG New Life Maximum: Initial Life + Endurance for Rolls");
 		parseInt(
 			(systemData.Vital.Life.max =
 				Number(systemData.Vital.Life.Initial) + Number(systemData.Characteristics.Body.Stats.Endurance.Roll))
 		);
-		//	console.log("Metanthropes RPG New Life Maximum:", systemData.Vital.Life.max);
-		//	console.log("Metanthropes RPG System | ====================================");
-		//	console.log("Metanthropes RPG Calculating Movement");
+		console.log("Metanthropes RPG System |", actor.name+"'s", "New Life Maximum:", systemData.Vital.Life.max);
 		parseInt((systemData.physical.movement.additional = Number(systemData.physical.movement.initial)));
 		parseInt((systemData.physical.movement.sprint = Number(Number(systemData.physical.movement.initial) * 5)));
-		//! do the update await thing!!!!FFS
-		//	console.log(
-		//		"Metanthropes RPG New Movement Value:",
-		//		systemData.physical.movement.initial,
-		//		"Additional:",
-		//		systemData.physical.movement.additional,
-		//		"Sprint:",
-		//		systemData.physical.movement.sprint
-		//	);
 		//? Calculate total Experience Spent Progressing Perks & Characteristics & Stats
 		//	console.log(
 		//		"Total Experience Spent automagically for",
@@ -481,11 +403,13 @@ export class MetanthropesActor extends Actor {
 	getRollData() {
 		const data = super.getRollData();
 		// Prepare character roll data.
+		//! should I exclude vehicles from this?
 		this._prepareCharacteristicsRollData(data);
 		return data;
 	}
 	_prepareCharacteristicsRollData(data) {
 		//? do the following in order to quickly see the actor's data structure to use in rolls
+		//! why doesn't combatant.actor get this?
 		// 	const actor = game.actors.getName("My Character Name");
 		//	console.log(actor.getRollData());
 		//! I don't need the below if I am going to call @Characteristics.Body.Stats. etc

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -114,8 +114,7 @@ export class MetanthropesActor extends Actor {
 		let statExperienceSpent = 0;
 		let advancementCount = 0;
 		let charzerofullpenalty = 0;
-		console.log("Metanthropes RPG System | ====================================");
-		console.log("Metanthropes RPG System | Preparing Characteristics & Stats for", this.type, "-", this.name);
+		console.log("Metanthropes RPG System | Actor Prep | Updating Characteristics & Stats for", this.type, "-", this.name);
 		for (const [CharKey, CharValue] of Object.entries(systemData.Characteristics)) {
 			//	console.log("Metanthropes RPG Calculating", CharKey, "Base: Initial + Progressed");
 			//	console.log(
@@ -139,7 +138,7 @@ export class MetanthropesActor extends Actor {
 			//? Add the experience spent on this characteristic to the total experience spent, only if Progressed is >0
 			if (advancementCount > 0) {
 				experienceSpent += characteristicExperienceSpent;
-				console.log("Metanthropes RPG System | Experience Spent to Progress", CharKey, "Characteristic:", characteristicExperienceSpent);
+				console.log("Metanthropes RPG System | Actor Prep | Experience Spent to Progress", CharKey, "Characteristic:", characteristicExperienceSpent);
 			}
 			parseInt((CharValue.Base = Number(CharValue.Initial) + Number(Number(CharValue.Progressed) * 5)));
 			//	console.log("Metanthropes RPG New", CharKey, "Base:", CharValue.Base);
@@ -161,8 +160,9 @@ export class MetanthropesActor extends Actor {
 			if (CharValue.Current <= 0) {
 				charzerofullpenalty = CharValue.Current;
 				CharValue.Current = 0;
-				ui.notifications.error(this.name + "'s " + CharKey + " has dropped to 0!");
-				console.log("Metanthropes RPG System |", CharKey, "has dropped to 0!");
+				//! decided not to spam everyone about this, however logging it to console
+				//ui.notifications.error(this.name + "'s " + CharKey + " has dropped to 0!");
+				console.log("Metanthropes RPG System | Actor Prep |", this.name+"'s", CharKey, "has dropped to 0!");
 			}
 			//	console.log("Metanthropes RPG New", CharKey, "Current:", CharValue.Current);
 			//	console.log("------------------------------------------------------------------------");
@@ -230,7 +230,9 @@ export class MetanthropesActor extends Actor {
 				);
 				if (StatValue.Roll <= 0) {
 					StatValue.Roll = 0;
-					ui.notifications.error(this.name + "'s " + StatKey + " has dropped to 0!");
+					//ui.notifications.error(this.name + "'s " + StatKey + " has dropped to 0!");
+					//! decided not to spam everyone about this, however logging it to console
+					console.log("Metanthropes RPG System | Actor Prep |", this.name+"'s", StatKey, "has dropped to 0!");
 					// console.log("Metanthropes RPG", StatKey, "has dropped to 0!");
 				}
 				// console.log("Metanthropes RPG Final", StatKey, "for Rolls:", StatValue.Roll);
@@ -285,8 +287,8 @@ export class MetanthropesActor extends Actor {
 		//	);
 		//}
 		//	console.log(this.name, "Has", systemData.Vital.Experience.Stored, "Stored Experience Remaining");
-		console.log("Metanthropes RPG System |", this.type, "-", this.name, "is Ready to Roll!");
-		console.log("Metanthropes RPG System | ====================================");
+		// console.log("Metanthropes RPG System |", this.type, "-", this.name, "is Ready to Roll!");
+		// console.log("Metanthropes RPG System | ====================================");
 	}
 	_prepareDerivedPerksData(actorData) {
 		if (actorData.type == "Vehicle") return;
@@ -303,8 +305,8 @@ export class MetanthropesActor extends Actor {
 		let experienceSpent = 0;
 		let advancementCount = 0;
 		let perkExperienceSpent = 0;
-		console.log("Metanthropes RPG System | ====================================");
-		console.log("Metanthropes RPG System | Preparing Perks for", this.type, "-", this.name);
+		// console.log("Metanthropes RPG System | ====================================");
+		console.log("Metanthropes RPG System | Actor Prep | Updating Perks for", this.type, "-", this.name);
 		//	console.log("Experience Spent before Perks:", experienceAlreadySpent);
 		//? Calculate the experience spent on Knowledge Perks
 		for (const [KnowPerkKey, KnowPerkValue] of Object.entries(systemData.Perks.Knowledge)) {
@@ -329,10 +331,10 @@ export class MetanthropesActor extends Actor {
 		//? Calculate total Experience Spent Progressing Perks & Characteristics & Stats
 		//? test if we have spent enough xp on the starting perks
 		if (experienceSpent < startingPerks * 100) {
-			console.log("Metanthropes RPG System |", this.name, "has not spent enough XP on starting perks!");
-			console.log("Metanthropes RPG System |", this.name, "has spent", experienceSpent, "XP on perks");
+			console.log("Metanthropes RPG System | Actor Prep |", this.name, "has not spent enough XP on starting perks!");
+			console.log("Metanthropes RPG System | Actor Prep |", this.name, "has spent", experienceSpent, "XP on perks");
 			console.log(
-				"Metanthropes RPG System |",
+				"Metanthropes RPG System | Actor Prep |",
 				this.name,
 				"needs to spend",
 				startingPerks * 100,
@@ -358,18 +360,18 @@ export class MetanthropesActor extends Actor {
 		);
 		if (systemData.Vital.Experience.Stored < 0) {
 			ui.notifications.warn(this.name + "'s Stored Experience is Negative!");
-			console.log("Metanthropes RPG System | ====================================");
-			console.log("Metanthropes RPG System | WARNING: Stored Experience is Negative!");
-			console.log("Metanthropes RPG System | ====================================");
+			
+			console.log("Metanthropes RPG System | Actor Prep | WARNING: Stored Experience is Negative!");
+			
 		}
 		//	console.log(this.name, "Has", systemData.Vital.Experience.Stored, "Stored Experience Remaining");
-		console.log("Metanthropes RPG System |", this.type, "-", this.name, "is ready for Action!");
-		console.log("Metanthropes RPG System | ====================================");
+		//console.log("Metanthropes RPG System |", this.type, "-", this.name, "is ready for Action!");
+		//console.log("Metanthropes RPG System | ====================================");
 	}
 	async _prepareDerivedMovementData(actorData) {
 		const systemData = actorData.system;
-		console.log("Metanthropes RPG System | ====================================");
-		console.log("Metanthropes RPG System | Preparing Movement for", this.type, "-", this.name);
+		//console.log("Metanthropes RPG System | ====================================");
+		console.log("Metanthropes RPG System | Actor Prep | Updating Movement for", this.type, "-", this.name);
 		//*first we will calculate the current values from buffs and conditions, then we take their modifiers and calculate the movement value
 		let speedinitial = Number(systemData.physical.speed.initial);
 		let weightinitial = Number(systemData.physical.weight.initial);
@@ -466,15 +468,15 @@ export class MetanthropesActor extends Actor {
 		await this.update({ "system.physical.movement.additional": movementvalue });
 		await this.update({ "system.physical.movement.sprint": movementvalue * 5 });
 		console.log(
-			"Metanthropes RPG System | Movement Value:",
+			"Metanthropes RPG System | Actor Prep | New Movement:",
 			movementvalue,
 			"Additional:",
 			movementvalue,
 			"Sprint:",
 			movementvalue * 5
 		);
-		console.log("Metanthropes RPG System |", this.name, "is ready to Move!");
-		console.log("Metanthropes RPG System | ====================================");
+		//console.log("Metanthropes RPG System |", this.name, "is ready to Move!");
+		//console.log("Metanthropes RPG System | ====================================");
 	}
 	getRollData() {
 		const data = super.getRollData();
@@ -503,7 +505,7 @@ export class MetanthropesActor extends Actor {
 		event.preventDefault();
 		// Check if the actor is in a combat
 		const combatant = this.combatant;
-		console.log("Metanthropes RPG System | inside onRollInitiative", combatant);
+		console.log("Metanthropes RPG System | inside onRollInitiative | do we ever use this?????", combatant);
 		if (!combatant) return;
 
 		//? Call the MetaInitiative function

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -179,7 +179,7 @@ export class MetanthropesActor extends Actor {
 			(systemData.Vital.Life.max =
 				Number(systemData.Vital.Life.Initial) + Number(systemData.Characteristics.Body.Stats.Endurance.Roll))
 		);
-		console.log("Metanthropes RPG System |", actor.name+"'s", "New Life Maximum:", systemData.Vital.Life.max);
+		console.log("Metanthropes RPG System |", actorData.name+"'s", "New Life Maximum:", systemData.Vital.Life.max);
 		parseInt((systemData.physical.movement.additional = Number(systemData.physical.movement.initial)));
 		parseInt((systemData.physical.movement.sprint = Number(Number(systemData.physical.movement.initial) * 5)));
 		//? Calculate total Experience Spent Progressing Perks & Characteristics & Stats

--- a/module/helpers/metaeval.mjs
+++ b/module/helpers/metaeval.mjs
@@ -1,6 +1,7 @@
 //* MetaEvaluate is the function that calculates the results of a roll and prints it to chat
 //* inputs like bonus is expected to be a positive number and multiAction and penalty are expected to be negative numbers
 export async function MetaEvaluate(actor, action, stat, statValue, multiAction = 0, bonus = 0, penalty = 0) {
+	//! We have to determine if this is a real actor or a token - or should I do that in the MetaRoll function?
 	console.log("Metanthropes RPG System | MetaEvaluate | Engaged for:", actor.name, action, stat, statValue, "Multi-Action:", multiAction, "Bonus:", bonus, "Penalty:", penalty)
 	//? evaluate the result of the roll
 	let result = null;
@@ -74,13 +75,21 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	} else {
 		message += `.<br><br>${actor.name} has ${currentDestiny} * 🤞 Destiny remaining.<br>`;
 	}
+	//? Buttons to Re-Roll MetaEvaluate results
 	//?add re-roll button to message, only if it's not a Critical and only if they have at least 1 destiny or more
 	if (!criticalSuccess && !criticalFailure && currentDestiny > 0) {
+		//? Need to have different buttons for the various actions, so the correct function is being re-called by the correct button id and the correct parameters are being passed
+		if (action === "StatRoll") {
 		message += `<div class="hide-button hidden"><br><button class="metaeval-reroll" data-idactor="${actor.id}"
 			data-stat="${stat}" data-statvalue="${statValue}" data-multiaction="${multiAction}"
 			data-bonus="${bonus}" data-penalty="${penalty}" data-action="${action}"
 			>Spend 🤞 Destiny to reroll</button><br><br></div>`;
+		} else if (action === "Initiative") {
+			message += `<div class="hide-button hidden"><br><button class="metainitiative-reroll" data-idactor="${actor.id}"
+				>Spend 🤞 Destiny to reroll</button><br><br></div>`;
+		}
 	}
+	//? Buttons for Keeping the results of MetaEvalute
 	//	if (action === "Initiative") {
 	//		message += `<div class="hide-button hidden"><button class="keep-initiative" data-idactor="${actor.id}"
 	//			data-stat="${stat}" data-statvalue="${statValue}" data-multiaction="${multiAction}"
@@ -89,7 +98,7 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	//	}
 	console.log(
 		"Metanthropes RPG System | MetaEvaluate | Finished for:",
-		actor.name,
+		actor.token.name,
 		"Action:",
 		action,
 		stat,
@@ -132,13 +141,13 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	//? Printing the results to chat
 	//if (action === "StatRoll") {
 		roll.toMessage({
-			speaker: ChatMessage.getSpeaker({ actor: actor }),
+			speaker: ChatMessage.getSpeaker({ 
+				actor: actor,
+				//token: combatant.token,
+				//alias: combatant.name, 
+			}),
 			flavor: message,
 			rollMode: game.settings.get("core", "rollMode"),
-			//I've used the optional chaining operator (?.) to check if effects-metapower exists before trying to access its value. If effects-metapower or its value is not defined, it will fall back to the "error no statrolled found" text using the nullish coalescing operator (??).
-			//content: item.system.effects-metapower?.value ?? "error no statrolled found",
-			//content: `<button class="custom-button">🤞</button>`,
-			//content seems to be overwriten by Dice So Nice, so maybe I can add my button here?
 			flags: { "metanthropes-system": { actorId: actor.id } },
 		});
 		//! I will need to figure out if(how?) I want to pass the combatant from metainitiative if I need to do that

--- a/module/helpers/metaeval.mjs
+++ b/module/helpers/metaeval.mjs
@@ -80,12 +80,12 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 			data-bonus="${bonus}" data-penalty="${penalty}" data-action="${action}"
 			>Spend 🤞 Destiny to reroll</button><br><br></div>`;
 	}
-	if (action === "Initiative") {
-		message += `<div class="hide-button hidden"><button class="keep-initiative" data-idactor="${actor.id}"
-			data-stat="${stat}" data-statvalue="${statValue}" data-multiaction="${multiAction}"
-			data-bonus="${bonus}" data-penalty="${penalty}" data-action="${action}"
-			>Keep Initiative of: ${resultLevel}</button><br><br></div>`;
-	}
+	//	if (action === "Initiative") {
+	//		message += `<div class="hide-button hidden"><button class="keep-initiative" data-idactor="${actor.id}"
+	//			data-stat="${stat}" data-statvalue="${statValue}" data-multiaction="${multiAction}"
+	//			data-bonus="${bonus}" data-penalty="${penalty}" data-action="${action}"
+	//			>Keep Initiative of: ${resultLevel}</button><br><br></div>`;
+	//	}
 	console.log(
 		"Metanthropes RPG System |",
 		"MetaEval Results for:",
@@ -118,14 +118,15 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	// the idea is to use these later in metapowers to spend your levels of success.
 	//? Setting Flags with results
 	await actor.setFlag("metanthropes-system", "lastrolled", {
-		resultLevel: resultLevel,
+		action: action,
 		//!I should change to follow this format:
 		metaEvaluate: resultLevel,
-		metaInitiative: resultLevel,
 	});
+	if (action === "Initiative") {
 	await actor.setFlag("metanthropes-system", "initiative", {
 		initiativeValue: resultLevel,
 	});
+}
 	//print message to chat and enable Dice So Nice to roll the dice and display the message
 	//? Printing the results to chat
 	//if (action === "StatRoll") {

--- a/module/helpers/metaeval.mjs
+++ b/module/helpers/metaeval.mjs
@@ -80,12 +80,12 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	if (!criticalSuccess && !criticalFailure && currentDestiny > 0) {
 		//? Need to have different buttons for the various actions, so the correct function is being re-called by the correct button id and the correct parameters are being passed
 		if (action === "StatRoll") {
-		message += `<div class="hide-button hidden"><br><button class="metaeval-reroll" data-idactor="${actor.id}"
+		message += `<div class="hide-button hidden"><br><button class="metaeval-reroll" data-actoruuid="${actor.uuid}"
 			data-stat="${stat}" data-statvalue="${statValue}" data-multiaction="${multiAction}"
 			data-bonus="${bonus}" data-penalty="${penalty}" data-action="${action}"
 			>Spend 🤞 Destiny to reroll</button><br><br></div>`;
 		} else if (action === "Initiative") {
-			message += `<div class="hide-button hidden"><br><button class="metainitiative-reroll" data-idactor="${actor.id}"
+			message += `<div class="hide-button hidden"><br><button class="metainitiative-reroll" data-actoruuid="${actor.uuid}"
 				>Spend 🤞 Destiny to reroll</button><br><br></div>`;
 		}
 	}
@@ -98,10 +98,10 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	//	}
 	console.log(
 		"Metanthropes RPG System | MetaEvaluate | Finished for:",
-		actor.token.name,
+		actor.name,
 		"Action:",
 		action,
-		stat,
+		stat+
 		":",
 		statValue,
 		"Roll:",
@@ -121,7 +121,9 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 		"Result Level:",
 		resultLevel,
 		"Current Destiny:",
-		currentDestiny
+		currentDestiny,
+		"Actor UUID:",
+		actor.uuid
 	);
 	//set flags for the actor to be used as the lastrolled values of your most recent roll.
 	// the idea is to use these later in metapowers to spend your levels of success.
@@ -148,7 +150,7 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 			}),
 			flavor: message,
 			rollMode: game.settings.get("core", "rollMode"),
-			flags: { "metanthropes-system": { actorId: actor.id } },
+			flags: { "metanthropes-system": { actoruuid: actor.uuid } },
 		});
 		//! I will need to figure out if(how?) I want to pass the combatant from metainitiative if I need to do that
 	//	} else if (action === "Initiative") {
@@ -172,13 +174,14 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 export async function MetaEvaluateReRoll(event) {
 	event.preventDefault();
 	const button = event.target;
-	const actorId = button.dataset.idactor;
+	const actorUUID = button.dataset.actoruuid;
 	const stat = button.dataset.stat;
 	const statValue = parseInt(button.dataset.statvalue);
 	const multiAction = parseInt(button.dataset.multiaction);
 	const bonus = parseInt(button.dataset.bonus);
 	const penalty = parseInt(button.dataset.penalty);
-	const actor = game.actors.get(actorId);
+	const actor = await fromUuid(actorUUID);
+	console.log("Metanthropes RPG System | MetaEvaluateReRoll | Engaged for:", actor, actorUUID)
 	const action = button.dataset.action;
 	let currentDestiny = actor.system.Vital.Destiny.value;
 	// make this function only available to the owner of the actor

--- a/module/helpers/metaeval.mjs
+++ b/module/helpers/metaeval.mjs
@@ -1,31 +1,33 @@
+//* MetaEvaluate is the function that calculates the results of a roll and prints it to chat
+//* inputs like bonus is expected to be a positive number and multiAction and penalty are expected to be negative numbers
 export async function MetaEvaluate(actor, action, stat, statValue, multiAction = 0, bonus = 0, penalty = 0) {
+	console.log("Metanthropes RPG System | MetaEvaluate | Engaged for:", actor.name, action, stat, statValue, "Multi-Action:", multiAction, "Bonus:", bonus, "Penalty:", penalty)
+	//? evaluate the result of the roll
 	let result = null;
 	let resultLevel = null;
 	const roll = await new Roll("1d100").evaluate({ async: true });
 	const total = roll.total;
-	//* bonus is expected to be a positive number and multiAction and penalty are expected to be negative numbers
 	let levelsOfSuccess = Math.floor((statValue + bonus + penalty + multiAction - total) / 10);
 	let levelsOfFailure = Math.floor((total - statValue - bonus - multiAction - penalty) / 10);
 	const criticalSuccess = total === 1;
 	const criticalFailure = total === 100;
 	let currentDestiny = actor.system.Vital.Destiny.value;
-	// this kicks-off the calculation, assuming that is is a failure
+	//? this kicks-off the calculation, assuming that is is a failure
 	if (total - multiAction - penalty > statValue + bonus) {
-		// in which case we don't care about what levels of success we have, so we set to 0 to avoid confusion later
+		//? in which case we don't care about what levels of success we have, so we set to 0 to avoid confusion later
 		result = "Failure 🟥";
 		levelsOfSuccess = 0;
-		// resultlevel is used to help with ordering combatants in initiative order
+		//? resultlevel is a numerical value to facilitate other functions to use the result of the roll
 		resultLevel = 0;
 	} else {
-		// if the calculation is <= to statValue, it's a success, so we reset the levels of failure to 0
+		//? if it's a success, similarly as above, we don't care about levels of failure
 		result = "Success 🟩";
 		levelsOfFailure = 0;
-		// resultlevel is used to help with ordering combatants in initiative order
 		resultLevel = 0.5;
 	}
-	//check for critical success or failure
+	//? check for critical success or failure
 	if (criticalSuccess) {
-		result = `🟩 Critical Success 🟩, rewarding ${actor.name} with +1 * 🤞`; //todo: add color and bold to crititals
+		result = `🟩 Critical Success 🟩, rewarding ${actor.name} with +1 * 🤞`;
 		currentDestiny += 1;
 		await actor.update({ "system.Vital.Destiny.value": Number(currentDestiny) });
 		levelsOfSuccess = 10;
@@ -37,13 +39,13 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 		}
 	}
 	if (criticalFailure) {
-		result = `🟥 Critical Failure 🟥, rewarding ${actor.name} with +1 * 🤞`; //todo: add color and bold to crititals
+		result = `🟥 Critical Failure 🟥, rewarding ${actor.name} with +1 * 🤞`;
 		currentDestiny += 1;
 		await actor.update({ "system.Vital.Destiny.value": Number(currentDestiny) });
 		levelsOfFailure = 10;
 		levelsOfSuccess = 0;
 	}
-	//* Beggining of the message to be printed to chat
+	//? Create the message to be printed to chat
 	let message = null;
 	if (action === "StatRoll") {
 		message = `Attempts a roll with ${stat} score of ${statValue}%`;
@@ -62,7 +64,6 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 		message += `, a Multi-Action reduction of ${multiAction}%`;
 	}
 	message += ` and the result is ${total}.<br><br>It is a ${result}`;
-	//! Here is the typical calculation for the final results
 	//? if we have levels of success or failure, add them to the message
 	if (levelsOfSuccess > 0) {
 		message += `, accumulating: ${levelsOfSuccess} * ✔️.<br><br>${actor.name} has ${currentDestiny} * 🤞 Destiny remaining.<br>`;
@@ -87,8 +88,7 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	//			>Keep Initiative of: ${resultLevel}</button><br><br></div>`;
 	//	}
 	console.log(
-		"Metanthropes RPG System |",
-		"MetaEval Results for:",
+		"Metanthropes RPG System | MetaEvaluate | Finished for:",
 		actor.name,
 		"Action:",
 		action,
@@ -116,6 +116,7 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	);
 	//set flags for the actor to be used as the lastrolled values of your most recent roll.
 	// the idea is to use these later in metapowers to spend your levels of success.
+	//! do I need to set flags here or maybe it's better to set them in MetaRoll?
 	//? Setting Flags with results
 	await actor.setFlag("metanthropes-system", "lastrolled", {
 		action: action,
@@ -140,7 +141,7 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 			//content seems to be overwriten by Dice So Nice, so maybe I can add my button here?
 			flags: { "metanthropes-system": { actorId: actor.id } },
 		});
-		//! I will need to figure out if I want to pass the combatant from metainitiative if I need to do that
+		//! I will need to figure out if(how?) I want to pass the combatant from metainitiative if I need to do that
 	//	} else if (action === "Initiative") {
 	//		//! not sure what's really different here, I should test some more
 	//		roll.toMessage({
@@ -156,6 +157,9 @@ export async function MetaEvaluate(actor, action, stat, statValue, multiAction =
 	//	}
 }
 //* This is the function that is called when the destiny re-roll button is clicked
+
+//! mipws tha itan kalytero na analavei to MetaRoll ta reroll???
+
 export async function MetaEvaluateReRoll(event) {
 	event.preventDefault();
 	const button = event.target;

--- a/module/helpers/metainitiative.mjs
+++ b/module/helpers/metainitiative.mjs
@@ -2,11 +2,10 @@
 /*
 //* Used primarly for determing if special effects apply to the initiative roll
 */
-import { MetaEvaluate } from "./metaeval.mjs";
 import { MetaRoll } from "../metanthropes/metaroll.mjs";
 export async function MetaInitiative(combatant) {
 	const actor = combatant.actor;
-	console.log("Metanthropes RPG System | MetaInitiative called for", actor.type, ":", actor.name);
+	console.log("Metanthropes RPG System | MetaInitiative starts for", actor.type, ":", actor.name);
 	//? Check for alternate Stat to use for Initiative
 	const reflexesStat = 'Reflexes';
 	const awarenessStat = 'Awareness';
@@ -17,8 +16,8 @@ export async function MetaInitiative(combatant) {
 	//? Check if the actor has the metapower "Danger Sense" equipped
 	const metapowers = actor.items.filter((item) => item.type === "Metapower");
 	const hasDangerSense = metapowers.some((metapower) => metapower.name === "Danger Sense");
-	//? Apply the alternate stat if the actor has Danger Sense
 	if (hasDangerSense) {
+		//? Apply the alternate stat values if the actor has Danger Sense
 		initiativeStat = awarenessStat;
 		initiativeStatValue = awarenessValue;
 	}
@@ -32,9 +31,9 @@ export async function MetaInitiative(combatant) {
 	//not this await MetaEvaluate (actor, action, initiativeStat, initiativeStatValue, 0, 0, 0);
 	await MetaRoll (actor, action, initiativeStat);
 	// Update the combatant with the new initiative value
-	let checkresult = await actor.getFlag("metanthropes-system", "lastrolled").metaInitiative;
+	let checkresult = await actor.getFlag("metanthropes-system", "initiative").initiativeValue;
+	console.log("Metanthropes RPG System |", actor.name, "rolled for Initiative with:", initiativeStat, initiativeStatValue, "and got:", checkresult);
 	await combatant.update({ initiative: checkresult });
-
 	// This is to check for hidden combatants and display a different message for them in chat
 	// Construct chat message data
 	//	let messageData = foundry.utils.mergeObject(
@@ -72,7 +71,7 @@ export async function MetaInitiativeReRoll(event) {
 	const actorId = button.dataset.idactor;
 	const actor = game.actors.get(actorId);
 	const combatant = game.combat.getCombatantByActor(actorId);
-	console.log("Metanthropes RPG  System | Do we get the correct combatant data?", combatant);
+	console.log("Metanthropes RPG  System | Rerolling MetaInitiative - do we get the correct combatant data?", combatant);
 	let currentDestiny = actor.system.Vital.Destiny.value;
 	// make this function only available to the owner of the actor
 	if ((actor && actor.isOwner) || game.user.isGM) {

--- a/module/helpers/metainitiative.mjs
+++ b/module/helpers/metainitiative.mjs
@@ -1,127 +1,40 @@
-// MetaInitiative function handles Initiative rolls
+//* MetaInitiative function handles Initiative rolls
+/*
+//* Used primarly for determing if special effects apply to the initiative roll
+*/
+import { MetaEvaluate } from "./metaeval.mjs";
+import { MetaRoll } from "../metanthropes/metaroll.mjs";
 export async function MetaInitiative(combatant) {
-	console.log("Metanthropes RPG MetaInitiative for combatant:", combatant);
 	const actor = combatant.actor;
-	console.log("Metanthropes RPG MetaInitiative called for actor: ", actor.name);
-	const reflexesStat = "Reflexes";
-	const awarenessStat = "Awareness";
+	console.log("Metanthropes RPG System | MetaInitiative called for", actor.type, ":", actor.name);
+	//? Check for alternate Stat to use for Initiative
+	const reflexesStat = 'Reflexes';
+	const awarenessStat = 'Awareness';
 	const reflexesValue = actor.system.Characteristics.Body.Stats.Reflexes.Roll;
-	console.log("Metanthropes RPG MetaInitiative - reflexesValue:", reflexesValue, "for actor:", actor.name);
 	const awarenessValue = actor.system.Characteristics.Soul.Stats.Awareness.Roll;
-	console.log("Metanthropes RPG MetaInitiative - awarenessValue:", awarenessValue, "for actor:", actor.name);
 	let initiativeStat = reflexesStat;
-	let statValue = reflexesValue;
-	// Check if the actor has the metapower "Danger Sense" equipped
+	let initiativeStatValue = reflexesValue;
+	//? Check if the actor has the metapower "Danger Sense" equipped
 	const metapowers = actor.items.filter((item) => item.type === "Metapower");
 	const hasDangerSense = metapowers.some((metapower) => metapower.name === "Danger Sense");
-	// If the actor has "Danger Sense", use Awareness for Initiative
+	//? Apply the alternate stat if the actor has Danger Sense
 	if (hasDangerSense) {
 		initiativeStat = awarenessStat;
-		statValue = awarenessValue;
+		initiativeStatValue = awarenessValue;
 	}
-	console.log("Metanthropes RPG MetaInitiative passed the Danger Sense for", actor, initiativeStat, statValue);
-	let result = null;
-	let resultLevel = null;
-	await actor.setFlag("metanthropes-system", "initiative", {
-		initiativeValue: resultLevel,
-	});
-	if (statValue <= 0) {
-		ui.notifications.error(
-			actor.name + " can't Roll for Initiative with " + initiativeStat + " Current value of 0!"
-		);
-		// Update the combatant with the new initiative value
-		await combatant.update({ initiative: resultLevel });
-		return;
-	}
-	const roll = await new Roll("1d100").evaluate({ async: true });
-	const total = roll.total;
-	let levelsOfSuccess = Math.floor((statValue - total) / 10);
-	let levelsOfFailure = Math.floor((total - statValue) / 10);
-	const criticalSuccess = total === 1;
-	const criticalFailure = total === 100;
-	let currentDestiny = actor.system.Vital.Destiny.value;
-	// this kicks-off the calculation, assuming that is is a failure
-	if (total > statValue) {
-		// in which case we don't care about what levels of success we have, so we set to 0 to avoid confusion later
-		result = "Failure 🟥";
-		levelsOfSuccess = 0;
-		// resultlevel is used to help with ordering combatants in initiative order
-		resultLevel = 0;
-	} else {
-		// if the calculation is <= to statValue, it's a success, so we reset the levels of failure to 0
-		result = "Success 🟩";
-		levelsOfFailure = 0;
-		// resultlevel is used to help with ordering combatants in initiative order
-		resultLevel = 0.5;
-	}
-	//check for critical success or failure
-	if (criticalSuccess) {
-		result = `🟩 Critical Success 🟩, rewarding ${actor.name} with +1 * 🤞`; //todo: add color and bold to crititals
-		currentDestiny += 1;
-		await actor.update({ "system.Vital.Destiny.value": Number(currentDestiny) });
-		levelsOfSuccess = 10;
-		if (statValue < 100) {
-			levelsOfSuccess += 0;
-		} else {
-			levelsOfSuccess += Math.floor((statValue - 100) / 10);
-		}
-	}
-	if (criticalFailure) {
-		result = `🟥 Critical Failure 🟥, rewarding ${actor.name} with +1 * 🤞`; //todo: add color and bold to crititals
-		currentDestiny += 1;
-		await actor.update({ "system.Vital.Destiny.value": Number(currentDestiny) });
-		levelsOfFailure = 10;
-	}
-	//* Beggining of the message to be printed to chat
-	let message = `Rolls for Initiative with ${initiativeStat} score of ${statValue}%`;
-	message += ` and the result is ${total}. Therefore it is a ${result}`;
-	// if we have levels of success or failure, add them to the message
-	if (levelsOfSuccess > 0) {
-		message += `, accumulating: ${levelsOfSuccess} * ✔️. ${actor.name} has ${currentDestiny} * 🤞 remaining.`;
-		resultLevel = levelsOfSuccess;
-	} else if (levelsOfFailure > 0) {
-		message += `, accumulating: ${levelsOfFailure} * ❌. ${actor.name} has ${currentDestiny} * 🤞 remaining.`;
-		resultLevel = -levelsOfFailure;
-	} else {
-		message += `. ${actor.name} has ${currentDestiny} * 🤞 remaining.`;
-	}
-	//add re-roll button to message
-	message += `<div class="hide-button layout-hide"><button class="metainitiative-re-roll" data-idactor="${actor.id}">🤞</button></div>`;
-	//console log for debugging
-	console.log(
-		"Metainitiative Results:",
-		"Stat:",
-		initiativeStat,
-		"Value:",
-		statValue,
-		"Roll:",
-		total,
-		"levelsOfSuccess:",
-		levelsOfSuccess,
-		"levelsOfFailure:",
-		levelsOfFailure,
-		"Result:",
-		result,
-		"Result Level:",
-		resultLevel,
-		"Destiny:",
-		currentDestiny
-	);
-	//print message to chat and enable Dice So Nice to roll the dice and display the message
-	roll.toMessage({
-		speaker: ChatMessage.getSpeaker({
-			actor: actor,
-			token: combatant.token,
-			alias: combatant.name,
-		}),
-		flavor: message,
-		rollMode: game.settings.get("core", "rollMode"),
-		//I've used the optional chaining operator (?.) to check if effects-metapower exists before trying to access its value. If effects-metapower or its value is not defined, it will fall back to the "error no statrolled found" text using the nullish coalescing operator (??).
-		//content: item.system.effects-metapower?.value ?? "error no statrolled found",
-		//content: `<button class="custom-button">🤞</button>`,
-		//content seems to be overwriten by Dice So Nice, so maybe I can add my button here?
-		flags: { "metanthropes-system": { actorId: actor.id } },
-	});
+	//? Call MetaEvaluate
+	let action = "Initiative";
+	//! do I need to reset the value in advance?
+	//	await actor.setFlag("metanthropes-system", "initiative", {
+	//		initiativeValue: resultLevel,
+	//	});
+	console.log("Metanthropes RPG System |", actor.name, "is rolling for Initiative with:", initiativeStat, initiativeStatValue);
+	//not this await MetaEvaluate (actor, action, initiativeStat, initiativeStatValue, 0, 0, 0);
+	await MetaRoll (actor, action, initiativeStat);
+	// Update the combatant with the new initiative value
+	let checkresult = await actor.getFlag("metanthropes-system", "lastrolled").metaInitiative;
+	await combatant.update({ initiative: checkresult });
+
 	// This is to check for hidden combatants and display a different message for them in chat
 	// Construct chat message data
 	//	let messageData = foundry.utils.mergeObject(
@@ -146,12 +59,6 @@ export async function MetaInitiative(combatant) {
 	//			: chatRollMode;
 	//!figure out how to play 1 sound for all initiative rolls?
 	// I will take these values and store them inside an initiative flag on the actor
-	await actor.setFlag("metanthropes-system", "initiative", {
-		initiativeValue: resultLevel,
-		statValue: statValue,
-	});
-	// Update the combatant with the new initiative value
-	await combatant.update({ initiative: resultLevel });
 }
 //! remove excess bonus / penalty / modifier if not needed at all for initiative
 // MetaInitiativeRollStat function is used to roll a stat and get the levels of success/failure and print the message to chat
@@ -165,7 +72,7 @@ export async function MetaInitiativeReRoll(event) {
 	const actorId = button.dataset.idactor;
 	const actor = game.actors.get(actorId);
 	const combatant = game.combat.getCombatantByActor(actorId);
-	console.log("Metanthropes RPG do we get the correct combatant data?", combatant);
+	console.log("Metanthropes RPG  System | Do we get the correct combatant data?", combatant);
 	let currentDestiny = actor.system.Vital.Destiny.value;
 	// make this function only available to the owner of the actor
 	if ((actor && actor.isOwner) || game.user.isGM) {

--- a/module/helpers/metainitiative.mjs
+++ b/module/helpers/metainitiative.mjs
@@ -82,10 +82,9 @@ export async function MetaInitiative(combatant) {
 export async function MetaInitiativeReRoll(event) {
 	event.preventDefault();
 	const button = event.target;
-	const actorId = button.dataset.idactor;
-	//! confusing the combatant witha actor - I need a better way to id the correct one
-	const actor = game.actors.get(actorId);
-	const combatant = game.combat.getCombatantByActor(actorId);
+	const actorUUID = button.dataset.actoruuid;
+	const actor = await fromUuid(actorUUID);
+	const combatant = game.combat.getCombatantByActor(actor);
 	console.log("Metanthropes RPG  System | Rerolling MetaInitiative for combatant:", combatant);
 	//! maybe split this off to another function?
 	//! should I have a promise if this fails to work?

--- a/module/helpers/metainitiative.mjs
+++ b/module/helpers/metainitiative.mjs
@@ -32,7 +32,7 @@ export async function MetaInitiative(combatant) {
 	await MetaRoll (actor, action, initiativeStat);
 	// Update the combatant with the new initiative value
 	let checkresult = await actor.getFlag("metanthropes-system", "initiative").initiativeValue;
-	console.log("Metanthropes RPG System | MetaInitiative | MetaRoll finished for", actor.name, "'s Initiative with:", initiativeStat, initiativeStatValue, "and the result was:", checkresult);
+	console.log("Metanthropes RPG System | MetaInitiative | MetaRoll Result for", actor.name, "'s Initiative with:", initiativeStat, initiativeStatValue, "was:", checkresult);
 	await combatant.update({ initiative: checkresult });
 	// This is to check for hidden combatants and display a different message for them in chat
 	// Construct chat message data
@@ -72,6 +72,8 @@ export async function MetaInitiativeReRoll(event) {
 	const actor = game.actors.get(actorId);
 	const combatant = game.combat.getCombatantByActor(actorId);
 	console.log("Metanthropes RPG  System | Rerolling MetaInitiative - do we get the correct combatant data?", combatant);
+	//! maybe split this off to another function?
+	//! should I have a promise if this fails to work?
 	let currentDestiny = actor.system.Vital.Destiny.value;
 	// make this function only available to the owner of the actor
 	if ((actor && actor.isOwner) || game.user.isGM) {
@@ -84,6 +86,9 @@ export async function MetaInitiativeReRoll(event) {
 			if (message) {
 				message.render();
 			}
+			//! do I need metainitiative here or should I just send it back to metaroll or metaevaluate?
+			//! core condition step process should dictate this
+			//! if I have to re-check for hunger, disease, pain, etc. then I need to send it back to metaroll that checks for these
 			MetaInitiative(combatant);
 		}
 	}

--- a/module/helpers/metainitiative.mjs
+++ b/module/helpers/metainitiative.mjs
@@ -5,7 +5,7 @@
 import { MetaRoll } from "../metanthropes/metaroll.mjs";
 export async function MetaInitiative(combatant) {
 	const actor = combatant.actor;
-	console.log("Metanthropes RPG System | MetaInitiative starts for", actor.type, ":", actor.name);
+	console.log("Metanthropes RPG System | MetaInitiative | Engaged for", actor.type, ":", actor.name);
 	//? Check for alternate Stat to use for Initiative
 	const reflexesStat = 'Reflexes';
 	const awarenessStat = 'Awareness';
@@ -27,12 +27,12 @@ export async function MetaInitiative(combatant) {
 	//	await actor.setFlag("metanthropes-system", "initiative", {
 	//		initiativeValue: resultLevel,
 	//	});
-	console.log("Metanthropes RPG System |", actor.name, "is rolling for Initiative with:", initiativeStat, initiativeStatValue);
+	console.log("Metanthropes RPG System | MetaInitiative | Engaging MetaRoll for", actor.name, "'s Initiative with:", initiativeStat, initiativeStatValue);
 	//not this await MetaEvaluate (actor, action, initiativeStat, initiativeStatValue, 0, 0, 0);
 	await MetaRoll (actor, action, initiativeStat);
 	// Update the combatant with the new initiative value
 	let checkresult = await actor.getFlag("metanthropes-system", "initiative").initiativeValue;
-	console.log("Metanthropes RPG System |", actor.name, "rolled for Initiative with:", initiativeStat, initiativeStatValue, "and got:", checkresult);
+	console.log("Metanthropes RPG System | MetaInitiative | MetaRoll finished for", actor.name, "'s Initiative with:", initiativeStat, initiativeStatValue, "and the result was:", checkresult);
 	await combatant.update({ initiative: checkresult });
 	// This is to check for hidden combatants and display a different message for them in chat
 	// Construct chat message data

--- a/module/helpers/metainitiative.mjs
+++ b/module/helpers/metainitiative.mjs
@@ -4,35 +4,49 @@
 */
 import { MetaRoll } from "../metanthropes/metaroll.mjs";
 export async function MetaInitiative(combatant) {
-	const actor = combatant.actor;
-	console.log("Metanthropes RPG System | MetaInitiative | Engaged for", actor.type, ":", actor.name);
+	//? Check to see if this is a linked actor
+	let actor = null;
+	if (combatant.token.actorLink) {
+		//? If it is, get data directly from the actor document
+		let actorId = combatant.actorId;
+		actor = game.actors.get(actorId);
+		// actor = combatant.actor;
+		} else {
+		//? If it's not linked, get data from the token document
+		actor = combatant.token.actor;
+		}
+	console.log("Metanthropes RPG System | MetaInitiative | Engaged for", actor.type + ":", actor.name);
 	//? Check for alternate Stat to use for Initiative
-	const reflexesStat = 'Reflexes';
-	const awarenessStat = 'Awareness';
-	const reflexesValue = actor.system.Characteristics.Body.Stats.Reflexes.Roll;
-	const awarenessValue = actor.system.Characteristics.Soul.Stats.Awareness.Roll;
+	const reflexesStat = "Reflexes";
+	const awarenessStat = "Awareness";
 	let initiativeStat = reflexesStat;
-	let initiativeStatValue = reflexesValue;
 	//? Check if the actor has the metapower "Danger Sense" equipped
 	const metapowers = actor.items.filter((item) => item.type === "Metapower");
 	const hasDangerSense = metapowers.some((metapower) => metapower.name === "Danger Sense");
 	if (hasDangerSense) {
 		//? Apply the alternate stat values if the actor has Danger Sense
 		initiativeStat = awarenessStat;
-		initiativeStatValue = awarenessValue;
 	}
 	//? Call MetaEvaluate
 	let action = "Initiative";
-	//! do I need to reset the value in advance?
-	//	await actor.setFlag("metanthropes-system", "initiative", {
-	//		initiativeValue: resultLevel,
-	//	});
-	console.log("Metanthropes RPG System | MetaInitiative | Engaging MetaRoll for", actor.name, "'s Initiative with:", initiativeStat, initiativeStatValue);
+	console.log(
+		"Metanthropes RPG System | MetaInitiative | Engaging MetaRoll for",
+		actor.name + "'s Initiative with",
+		initiativeStat
+	);
+	await actor.getRollData();
 	//not this await MetaEvaluate (actor, action, initiativeStat, initiativeStatValue, 0, 0, 0);
-	await MetaRoll (actor, action, initiativeStat);
+	await MetaRoll(actor, action, initiativeStat);
 	// Update the combatant with the new initiative value
 	let checkresult = await actor.getFlag("metanthropes-system", "initiative").initiativeValue;
-	console.log("Metanthropes RPG System | MetaInitiative | MetaRoll Result for", actor.name, "'s Initiative with:", initiativeStat, initiativeStatValue, "was:", checkresult);
+	console.log(
+		"Metanthropes RPG System | MetaInitiative | MetaRoll Result for",
+		actor.name + "'s Initiative with",
+		initiativeStat,
+		//initiativeStatValue,
+		"was:",
+		checkresult
+	);
 	await combatant.update({ initiative: checkresult });
 	// This is to check for hidden combatants and display a different message for them in chat
 	// Construct chat message data
@@ -69,9 +83,10 @@ export async function MetaInitiativeReRoll(event) {
 	event.preventDefault();
 	const button = event.target;
 	const actorId = button.dataset.idactor;
+	//! confusing the combatant witha actor - I need a better way to id the correct one
 	const actor = game.actors.get(actorId);
 	const combatant = game.combat.getCombatantByActor(actorId);
-	console.log("Metanthropes RPG  System | Rerolling MetaInitiative - do we get the correct combatant data?", combatant);
+	console.log("Metanthropes RPG  System | Rerolling MetaInitiative for combatant:", combatant);
 	//! maybe split this off to another function?
 	//! should I have a promise if this fails to work?
 	let currentDestiny = actor.system.Vital.Destiny.value;

--- a/module/metanthropes-system.mjs
+++ b/module/metanthropes-system.mjs
@@ -347,11 +347,10 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
 // Hook to look for re-rolls of meta dice in chat
 // Add event listener for re-roll button click, hiding the button for non-owners
 Hooks.on("renderChatMessage", async (message, html) => {
-	//? Get the actor from the message
-	const actorId = message.getFlag("metanthropes-system", "actorId");
-	//? all our messages have the actorId flag set, so if it's not our message, return.
-	if (!actorId) return;
-	const actor = game.actors.get(actorId);
+	//? Get the actor from the message - all our messages have the actoruuid flag set, so if it's not our message, return.
+	let actorUUID = message.getFlag("metanthropes-system", "actoruuid");
+	if (!actorUUID) return;
+	let actor = await fromUuid(actorUUID);
 	//? Check if the current user is the owner of the actor
 	if (game.user.name === actor.system.metaowner.value || game.user.isGM) {
 		//? Unhide the buttons - assumes DF Chat Enhancements module is installed (provides hidden class that works)

--- a/module/metanthropes-system.mjs
+++ b/module/metanthropes-system.mjs
@@ -303,8 +303,8 @@ Hooks.once("enhancedTerrainLayer.ready", (RuleProvider) => {
 	console.log("Metanthropes RPG System | Enhanced Terrain Layer Integration Started");
 	class MetanthropesRuleProvider extends RuleProvider {
 		calculateCombinedCost(terrain, options) {
-			let cost;
-			// Calculate the cost for this terrain
+			//? I want to reduce movement by 1 for every 2 points of terrain (?)
+			let cost = terrain - 1;
 			return cost;
 		}
 	}

--- a/module/metanthropes-system.mjs
+++ b/module/metanthropes-system.mjs
@@ -354,7 +354,7 @@ Hooks.on("renderChatMessage", async (message, html) => {
 	const actor = game.actors.get(actorId);
 	//? Check if the current user is the owner of the actor
 	if (game.user.name === actor.system.metaowner.value || game.user.isGM) {
-		//? Unhide the buttons - assumes DF Chat Enhancements module is installed (provides hidden class)
+		//? Unhide the buttons - assumes DF Chat Enhancements module is installed (provides hidden class that works)
 		html.find(".hide-button").removeClass("hidden");
 		//? Listen for Re-Roll button clicks
 		html.find(".rolld10-reroll").on("click", Rolld10ReRoll);
@@ -366,7 +366,7 @@ Hooks.on("renderChatMessage", async (message, html) => {
 		html.find(".re-roll-damage").on("click", ReRollDamage);
 		html.find(".re-roll-healing").on("click", ReRollHealing);
 		//? Listen for metainitiative re-roll
-		html.find(".metainitiative-re-roll").on("click", MetaInitiativeReRoll);
+		html.find(".metainitiative-reroll").on("click", MetaInitiativeReRoll);
 		//? Listen for activations
 		html.find(".metapower-activate").on("click", MetapowerActivate);
 		html.find(".possession-use").on("click", PossessionUse);

--- a/module/metanthropes/combat.mjs
+++ b/module/metanthropes/combat.mjs
@@ -73,7 +73,7 @@ export class MetanthropesCombat extends Combat {
 	 * @returns {Promise<Combat>}       A promise which resolves to the updated Combat document once updates are complete.
 	 */
 	async rollInitiative(ids, { formula = null, updateTurn = true, messageOptions = {} } = {}) {
-		console.log("Metanthropes RPG System | Combat: rollInitiative Activated");
+		console.log("Metanthropes RPG System | Combat | rollInitiative Engaged");
 		// Structure input data
 		ids = typeof ids === "string" ? [ids] : ids;
 		const currentId = this.combatant?.id;
@@ -85,10 +85,10 @@ export class MetanthropesCombat extends Combat {
 			const combatant = this.combatants.get(id);
 			if (!combatant?.isOwner) continue;
 			// Produce an initiative roll for the Combatant
-			console.log("Metanthropes RPG System | Combat: calls MetaInitiative for combatant:", combatant);
+			console.log("Metanthropes RPG System | Combat | Engaging MetaInitiative for combatant:", combatant);
 			await MetaInitiative(combatant);
 			let initiativeResult = combatant.actor.getFlag("metanthropes-system", "initiative").initiativeValue;
-			console.log("Metanthropes RPG System | Combat: MetaInitiative finished, updating combatant with new initiative:", initiativeResult);
+			console.log("Metanthropes RPG System | Combat | MetaInitiative finished, updating combatant with new initiative:", initiativeResult);
 			updates.push({ _id: id, initiative: initiativeResult });
 			//	// Construct chat message data
 			//	let messageData = foundry.utils.mergeObject(

--- a/module/metanthropes/combat.mjs
+++ b/module/metanthropes/combat.mjs
@@ -12,16 +12,16 @@ export class MetanthropesCombat extends Combat {
 		const astatValue = a.actor.getFlag("metanthropes-system", "initiative")?.statValue ?? -Infinity;
 		const bstatValue = b.actor.getFlag("metanthropes-system", "initiative")?.statValue ?? -Infinity;
 		console.log("Metanthropes RPG - from within sortCombatants  === +++ === +++ ===");
-		console.log("a:", a);
-		console.log("b:", b);
-		console.log("a.initiative:", a.initiative);
-		console.log("b.initiative:", b.initiative);
-		console.log("astatValue:", astatValue);
-		console.log("bstatValue:", bstatValue);
-		console.log("ia:", ia);
-		console.log("ib:", ib);
-		console.log("ib - ia:", ib - ia);
-		console.log("astatValue > bstatValue:", astatValue > bstatValue);
+		//	console.log("a:", a);
+		//	console.log("b:", b);
+		//	console.log("a.initiative:", a.initiative);
+		//	console.log("b.initiative:", b.initiative);
+		//	console.log("astatValue:", astatValue);
+		//	console.log("bstatValue:", bstatValue);
+		//	console.log("ia:", ia);
+		//	console.log("ib:", ib);
+		//	console.log("ib - ia:", ib - ia);
+		//	console.log("astatValue > bstatValue:", astatValue > bstatValue);
 		// sort by initiative first, then sort by statValue if the initiative is the same
 		return ib - ia || (astatValue > bstatValue ? -1 : 1);
 	}
@@ -73,9 +73,7 @@ export class MetanthropesCombat extends Combat {
 	 * @returns {Promise<Combat>}       A promise which resolves to the updated Combat document once updates are complete.
 	 */
 	async rollInitiative(ids, { formula = null, updateTurn = true, messageOptions = {} } = {}) {
-		console.log("=======++++++++++++++============");
-		console.log("Metanthropes RPG inside rollInitiative");
-		console.log("=======++++++++++++++============");
+		console.log("Metanthropes RPG System | inside rollInitiative");
 		// Structure input data
 		ids = typeof ids === "string" ? [ids] : ids;
 		const currentId = this.combatant?.id;

--- a/module/metanthropes/combat.mjs
+++ b/module/metanthropes/combat.mjs
@@ -11,7 +11,7 @@ export class MetanthropesCombat extends Combat {
 		const ib = Number.isNumeric(b.initiative) ? b.initiative : -Infinity;
 		const astatValue = a.actor.getFlag("metanthropes-system", "initiative")?.statValue ?? -Infinity;
 		const bstatValue = b.actor.getFlag("metanthropes-system", "initiative")?.statValue ?? -Infinity;
-		console.log("Metanthropes RPG - from within sortCombatants  === +++ === +++ ===");
+		// console.log("Metanthropes RPG - from within sortCombatants  === +++ === +++ ===");
 		//	console.log("a:", a);
 		//	console.log("b:", b);
 		//	console.log("a.initiative:", a.initiative);
@@ -73,7 +73,7 @@ export class MetanthropesCombat extends Combat {
 	 * @returns {Promise<Combat>}       A promise which resolves to the updated Combat document once updates are complete.
 	 */
 	async rollInitiative(ids, { formula = null, updateTurn = true, messageOptions = {} } = {}) {
-		console.log("Metanthropes RPG System | inside rollInitiative");
+		console.log("Metanthropes RPG System | Combat: rollInitiative Activated");
 		// Structure input data
 		ids = typeof ids === "string" ? [ids] : ids;
 		const currentId = this.combatant?.id;
@@ -85,12 +85,10 @@ export class MetanthropesCombat extends Combat {
 			const combatant = this.combatants.get(id);
 			if (!combatant?.isOwner) continue;
 			// Produce an initiative roll for the Combatant
-			const roll = await MetaInitiative(combatant);
-			console.log("=======++++++++++++++============");
-			console.log("Metanthropes RPG using metainitiative:", roll, "combatant:", combatant);
-			console.log("=======++++++++++++++============");
-			const initiativeData = combatant.actor.getFlag("metanthropes-system", "initiative");
-			const initiativeResult = initiativeData.initiativeValue;
+			console.log("Metanthropes RPG System | Combat: calls MetaInitiative for combatant:", combatant);
+			await MetaInitiative(combatant);
+			let initiativeResult = combatant.actor.getFlag("metanthropes-system", "initiative").initiativeValue;
+			console.log("Metanthropes RPG System | Combat: MetaInitiative finished, updating combatant with new initiative:", initiativeResult);
 			updates.push({ _id: id, initiative: initiativeResult });
 			//	// Construct chat message data
 			//	let messageData = foundry.utils.mergeObject(

--- a/module/metanthropes/combattracker.mjs
+++ b/module/metanthropes/combattracker.mjs
@@ -12,7 +12,7 @@ export class MetaCombatTracker extends CombatTracker {
 		const options = super._getEntryContextOptions(combatant);
 		// Add a new option to the context menu
 		options.push({
-			name: "Roll MetaInitiative",
+			name: "Force Roll MetaInitiative",
 			icon: '<i class="fa-solid fa-dice-d10"></i><i class="fa-light fa-dice-d10"></i>',
 			condition: game.user.isGM,
 			callback: (li) => {

--- a/module/metanthropes/metaroll.mjs
+++ b/module/metanthropes/metaroll.mjs
@@ -6,7 +6,6 @@ import { MetaEvaluate } from "../helpers/metaeval.mjs";
  * we determine if we need additional info if it is more than a stat roll
  */
 
-
 //! genikotero question einai ean thelw na pernaw ta re-rolls apo to MetaRoll prwta
 //! px to hunger tha prepei na to pernaw kathe fora poy kanw re-roll? mporw na kanw destiny spend gia re-rolling tou hunger?
 //! episis na analavei to MetaRoll ta chat messages? why/why not?
@@ -14,8 +13,23 @@ import { MetaEvaluate } from "../helpers/metaeval.mjs";
 //! thumisou na vgaleis ta ui.notifications.error apo to actor - kai isws na ta kaneis chat messages ???
 
 export async function MetaRoll(actor, action, stat) {
-	console.log("Metanthropes RPG System | MetaRoll | Engaged for", actor.type+":", actor.name+"'s", action, "with:", stat);
-	const statValue = actor.system.RollStats[stat];
+	let statValue;
+	//? Check if it's a linked actor or not
+	if (actor.istoken) {
+		//? For tokens we take the data from the token, not the original actor
+		statValue = actor.data.system.RollStats[stat];
+	} else {
+		//? For linked actors we take the data from the actor document directly
+		statValue = actor.system.RollStats[stat];
+	}
+	console.log(
+		"Metanthropes RPG System | MetaRoll | Engaged for",
+		actor.type + ":",
+		actor.name + "'s",
+		action,
+		"with",
+		stat
+	);
 	const disease = actor.system.Characteristics.Body.CoreConditions.Diseased;
 	const pain = actor.system.Characteristics.Mind.CoreConditions.Pain;
 	const hunger = actor.system.Characteristics.Mind.CoreConditions.Hunger; //also fatigue?
@@ -54,7 +68,20 @@ export async function MetaRoll(actor, action, stat) {
 	let multiAction = 0;
 	let bonus = 0;
 	let penalty = diseasePenalty;
-	console.log("Metanthropes RPG System | MetaRoll | Engaging MetaEvaluate for:", actor.name+"'s", action, "with:", stat, statValue, "Multi-Action:", multiAction, "Bonus:", bonus, "Penalty:", penalty);
+	console.log(
+		"Metanthropes RPG System | MetaRoll | Engaging MetaEvaluate for:",
+		actor.name + "'s",
+		action,
+		"with",
+		stat,
+		statValue,
+		"Multi-Action:",
+		multiAction,
+		"Bonus:",
+		bonus,
+		"Penalty:",
+		penalty
+	);
 	await MetaEvaluate(actor, action, stat, statValue, multiAction, bonus, penalty);
 	let checkresult = await actor.getFlag("metanthropes-system", "lastrolled").metaEvaluate;
 	console.log(
@@ -62,8 +89,7 @@ export async function MetaRoll(actor, action, stat) {
 		actor.name,
 		"Action:",
 		action,
-		stat,
-		":",
+		stat + ":",
 		statValue,
 		"Result:",
 		checkresult

--- a/module/metanthropes/metaroll.mjs
+++ b/module/metanthropes/metaroll.mjs
@@ -17,7 +17,8 @@ export async function MetaRoll(actor, action, stat) {
 	//? Check if it's a linked actor or not
 	if (actor.istoken) {
 		//? For tokens we take the data from the token, not the original actor
-		statValue = actor.data.system.RollStats[stat];
+		//statValue = actor.data.system.RollStats[stat];
+		statValue = actor.token.document.actor.system.RollStats[stat];
 	} else {
 		//? For linked actors we take the data from the actor document directly
 		statValue = actor.system.RollStats[stat];

--- a/module/metanthropes/metaroll.mjs
+++ b/module/metanthropes/metaroll.mjs
@@ -5,8 +5,16 @@ import { MetaEvaluate } from "../helpers/metaeval.mjs";
  * we dermine if it's a simple roll, a detailed roll or a re-roll of existing results
  * we determine if we need additional info if it is more than a stat roll
  */
+
+
+//! genikotero question einai ean thelw na pernaw ta re-rolls apo to MetaRoll prwta
+//! px to hunger tha prepei na to pernaw kathe fora poy kanw re-roll? mporw na kanw destiny spend gia re-rolling tou hunger?
+//! episis na analavei to MetaRoll ta chat messages? why/why not?
+//! testing rq: protagonists, humans, metatherions klp klp linked kai mh, paizoune swsta? emfanizontai ola swsta k me to initiative??
+//! thumisou na vgaleis ta ui.notifications.error apo to actor - kai isws na ta kaneis chat messages ???
+
 export async function MetaRoll(actor, action, stat) {
-	console.log("Metanthropes RPG System | MetaRoll called for", actor.type, ":", actor.name, "Action:", action, "Stat:", stat);
+	console.log("Metanthropes RPG System | MetaRoll | Engaged for", actor.type+":", actor.name+"'s", action, "with:", stat);
 	const statValue = actor.system.RollStats[stat];
 	const disease = actor.system.Characteristics.Body.CoreConditions.Diseased;
 	const pain = actor.system.Characteristics.Mind.CoreConditions.Pain;
@@ -42,16 +50,15 @@ export async function MetaRoll(actor, action, stat) {
 			diseasePenalty = -(disease * 10);
 		}
 	}
-	//! ready to call MetaEvaluate for simple roll without any additional bonuses or penalties
-	//* send the data we collected to the MetaRollStat function
+	//? ready to call MetaEvaluate for simple roll without any additional bonuses or penalties
 	let multiAction = 0;
 	let bonus = 0;
 	let penalty = diseasePenalty;
-	console.log("Metanthropes RPG System | MetaRoll calls for MetaEvaluate for:", actor.name, "'s", action, "with:", stat, statValue, "Multi-Action:", multiAction, "Bonus:", bonus, "Penalty:", penalty);
+	console.log("Metanthropes RPG System | MetaRoll | Engaging MetaEvaluate for:", actor.name+"'s", action, "with:", stat, statValue, "Multi-Action:", multiAction, "Bonus:", bonus, "Penalty:", penalty);
 	await MetaEvaluate(actor, action, stat, statValue, multiAction, bonus, penalty);
 	let checkresult = await actor.getFlag("metanthropes-system", "lastrolled").metaEvaluate;
 	console.log(
-		"Metanthropes RPG System | MetaRoll Finished for:",
+		"Metanthropes RPG System | MetaRoll | MetaEvaluate Result for",
 		actor.name,
 		"Action:",
 		action,
@@ -61,6 +68,7 @@ export async function MetaRoll(actor, action, stat) {
 		"Result:",
 		checkresult
 	);
+	console.log("Metanthropes RPG System | MetaRoll | Finished");
 }
 
 //! different function if called via right-click, allowing to set options
@@ -68,6 +76,7 @@ export async function MetaRollCustom(actor, action, stat) {
 	const statValue = actor.system.RollStats[stat];
 	const disease = actor.system.Characteristics.Body.CoreConditions.Diseased;
 	//! add the similar checks as above
+	//! could I instead somehow extend the MetaRoll function to accept additional parameters?
 	//? calculate the max number of multi-actions possible based on the stat value
 	const maxMultiActions = Math.floor((statValue - 1) / 10);
 	const multiActionOptions = Array.from({ length: maxMultiActions - 1 }, (_, i) => i + 2);
@@ -106,7 +115,7 @@ export async function MetaRollCustom(actor, action, stat) {
 			roll: {
 				label: dialogbuttonlabel,
 				callback: async (html) => {
-					//collect multi-action value
+					//? collect multi-action value
 					let multiAction = html.find("#multiActionCount").val();
 					if (multiAction === "no") {
 						multiAction = 0;
@@ -114,10 +123,11 @@ export async function MetaRollCustom(actor, action, stat) {
 						let selectedMultiActions = parseInt(html.find("#multiActionCount").val());
 						multiAction = selectedMultiActions * -10;
 					}
-					// collect bonus and penalty values
+					//? collect bonus and penalty values
 					let bonus = parseInt(html.find("#bonus").val());
 					let penalty = -parseInt(html.find("#penalty").val());
 					//? Check for disease
+					//! is this the right place to do so?
 					//* disease is expected to be a positive number, where as penalty is expected to be negative
 					if (disease > 0) {
 						//? check if penalty is worse than the disease level and set it accordingly
@@ -125,7 +135,7 @@ export async function MetaRollCustom(actor, action, stat) {
 							penalty = -(disease * 10);
 						}
 					}
-					//send the data we collected to the MetaEvaluate function
+					//?send the data we collected to the MetaEvaluate function
 					MetaEvaluate(actor, action, stat, statValue, multiAction, bonus, penalty);
 				},
 			},

--- a/module/metanthropes/metaroll.mjs
+++ b/module/metanthropes/metaroll.mjs
@@ -47,11 +47,11 @@ export async function MetaRoll(actor, action, stat) {
 	let multiAction = 0;
 	let bonus = 0;
 	let penalty = diseasePenalty;
+	console.log("Metanthropes RPG System | MetaRoll calls for MetaEvaluate for:", actor.name, "'s", action, "with:", stat, statValue, "Multi-Action:", multiAction, "Bonus:", bonus, "Penalty:", penalty);
 	await MetaEvaluate(actor, action, stat, statValue, multiAction, bonus, penalty);
 	let checkresult = await actor.getFlag("metanthropes-system", "lastrolled").metaEvaluate;
 	console.log(
-		"Metanthropes RPG System |",
-		"MetaRoll Results for:",
+		"Metanthropes RPG System | MetaRoll Finished for:",
 		actor.name,
 		"Action:",
 		action,

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -186,12 +186,13 @@ export class MetanthropesActorSheet extends ActorSheet {
 		if (dataset.rollType) {
 			console.log("Metanthropes RPG System | We are about to make a new Roll for a", dataset.rollType);
 			console.log("Metanthropes RPG System | Dataset:", dataset);
-			if (dataset.rollType == "Stat") {
+			if (dataset.rollType == "StatRoll") {
 				const actor = this.actor;
+				const action = dataset.rollType;
 				const stat = dataset.stat;
 				console.log("Metanthropes RPG System | Rolling a Stat for:", actor.name, "'s", stat);
 				console.log("Metanthropes RPG System | ====================================");
-				MetaRoll(actor, stat);
+				MetaRoll(actor, action, stat);
 			} else if (dataset.rollType == "Metapower") {
 				const actor = this.actor;
 				const stat = dataset.stat;
@@ -278,12 +279,13 @@ export class MetanthropesActorSheet extends ActorSheet {
 			console.log("Metanthropes RPG System | ====================================");
 			console.log("Metanthropes RPG System | We are about to make a new Custom Roll for a", dataset.rollType);
 			console.log("Metanthropes RPG System | Dataset:", dataset);
-			if (dataset.rollType == "Stat") {
+			if (dataset.rollType == "StatRoll") {
 				const actor = this.actor;
+				const action = dataset.rollType;
 				const stat = dataset.stat;
 				console.log("Metanthropes RPG System | Rolling a Stat for:", actor.name, "'s", stat);
 				console.log("Metanthropes RPG System | ====================================");
-				MetaRollCustom(actor, stat);
+				MetaRollCustom(actor, action, stat);
 			} else if (dataset.rollType == "Metapower") {
 				const actor = this.actor;
 				const stat = dataset.stat;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -177,7 +177,7 @@ export class MetanthropesActorSheet extends ActorSheet {
 	}
 	//code from boilerplate on rolls
 	async _onRoll(event) {
-		console.log("Metanthropes RPG System | Evaluating a new _onRoll(event)");
+		console.log("Metanthropes RPG System | Evaluating a new _onRoll(event) for this:", this);
 		event.preventDefault();
 		const element = event.currentTarget;
 		const dataset = element.dataset;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -177,21 +177,19 @@ export class MetanthropesActorSheet extends ActorSheet {
 	}
 	//code from boilerplate on rolls
 	async _onRoll(event) {
-		console.log("Metanthropes RPG System | ====================================");
 		console.log("Metanthropes RPG System | Evaluating a new _onRoll(event)");
 		event.preventDefault();
 		const element = event.currentTarget;
 		const dataset = element.dataset;
-		// Handle item rolls.
+		//? Handle all types of rolls here based on the rollType (data-roll-type)
 		if (dataset.rollType) {
-			console.log("Metanthropes RPG System | We are about to make a new Roll for a", dataset.rollType);
-			console.log("Metanthropes RPG System | Dataset:", dataset);
+			//console.log("Metanthropes RPG System | We are about to make a new Roll for a", dataset.rollType);
+			//console.log("Metanthropes RPG System | Dataset:", dataset);
 			if (dataset.rollType == "StatRoll") {
 				const actor = this.actor;
 				const action = dataset.rollType;
 				const stat = dataset.stat;
-				console.log("Metanthropes RPG System | Rolling a Stat for:", actor.name, "'s", stat);
-				console.log("Metanthropes RPG System | ====================================");
+				console.log("Metanthropes RPG System | Engaging MetaRoll for:", actor.name+"'s", action, "with", stat);
 				MetaRoll(actor, action, stat);
 			} else if (dataset.rollType == "Metapower") {
 				const actor = this.actor;

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"id": "metanthropes-system",
 	"title": "Metanthropes RPG",
 	"description": "Metanthropes RPG System for FoundryVTT",
-	"version": "0.7.22",
+	"version": "0.7.23",
 	"compatibility": {
 		"minimum": "10",
 		"verified": "11.306",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"id": "metanthropes-system",
 	"title": "Metanthropes RPG",
 	"description": "Metanthropes RPG System for FoundryVTT",
-	"version": "0.7.21",
+	"version": "0.7.22",
 	"compatibility": {
 		"minimum": "10",
 		"verified": "11.306",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"id": "metanthropes-system",
 	"title": "Metanthropes RPG",
 	"description": "Metanthropes RPG System for FoundryVTT",
-	"version": "0.7.23",
+	"version": "0.7.24",
 	"compatibility": {
 		"minimum": "10",
 		"verified": "11.306",

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"id": "metanthropes-system",
 	"title": "Metanthropes RPG",
 	"description": "Metanthropes RPG System for FoundryVTT",
-	"version": "0.7.25",
+	"version": "0.7.26",
 	"compatibility": {
 		"minimum": "10",
 		"verified": "11.307",

--- a/system.json
+++ b/system.json
@@ -2,10 +2,10 @@
 	"id": "metanthropes-system",
 	"title": "Metanthropes RPG",
 	"description": "Metanthropes RPG System for FoundryVTT",
-	"version": "0.7.24",
+	"version": "0.7.25",
 	"compatibility": {
 		"minimum": "10",
-		"verified": "11.306",
+		"verified": "11.307",
 		"maximum": "11"
 	},
 	"authors": [

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
 	"id": "metanthropes-system",
 	"title": "Metanthropes RPG",
 	"description": "Metanthropes RPG System for FoundryVTT",
-	"version": "0.7.20",
+	"version": "0.7.21",
 	"compatibility": {
 		"minimum": "10",
 		"verified": "11.306",

--- a/template.json
+++ b/template.json
@@ -539,7 +539,7 @@
 							"type": "number",
 							"dtype": "Number",
 							"label": "Starting Perks",
-							"value": 2
+							"value": 0
 						}
 					}
 				}

--- a/templates/actor/protagonist-sheet.hbs
+++ b/templates/actor/protagonist-sheet.hbs
@@ -3,9 +3,9 @@
 		<div class="layout-container-actorinfo style-container-actorinfo">
 			{{#if system.metaowner.value}}
 				<div class="layout-container-actorinfo-details">
-					<img src="systems/metanthropes-system/artwork/Meta-Avatar-Rotating.gif" alt="Metanthropes"
+					<img src="systems/metanthropes-system/artwork/Meta-Avatar-Rotating.gif" alt="Metanthropes RPG"
 						title="Metanthropes RPG {{actor.type}}" height="85" width="85"
-						style="border: none; border-radius: 80%" />
+						style="border: none; border-radius: 50%" />
 				</div>
 				<div class="layout-container-actorinfo-details">
 					<div class="style-actorinfo-tier3">

--- a/templates/helpers/actor-charstats.hbs
+++ b/templates/helpers/actor-charstats.hbs
@@ -69,7 +69,7 @@
 							</select>
 						</p>
 					</div>
-					<div class="style-cs-rolls" data-roll-type="Stat" data-stat="{{@key}}">
+					<div class="style-cs-rolls" data-roll-type="StatRoll" data-stat="{{@key}}">
 						{{this.Roll}}
 					</div>
 					<div>

--- a/templates/helpers/actor-charstats.hbs
+++ b/templates/helpers/actor-charstats.hbs
@@ -22,7 +22,7 @@
 				<div>
 					<p class="style-cs-buffs">🛡️ <label
 							for="system.Characteristics.{{@key}}.Buff.Current">{{this.Buff.Name}}</label></p>
-					<p class="style-cs-buffs"><select class="style-cs-buffs"
+					<p class="style-cs-buffs" title="Buff Level"><select class="style-cs-buffs"
 							name="system.Characteristics.{{@key}}.Buff.Current"
 							id="system.Characteristics.{{@key}}.Buff.Current" data-dtype="Number">
 							<option value="0" {{selected Buff.Current 0}}>0</option>
@@ -35,7 +35,7 @@
 					</p>
 					<p class="style-cs-conditions">💀 <label
 							for="system.Characteristics.{{@key}}.Condition.Current">{{this.Condition.Name}}</label></p>
-					<p class="style-cs-conditions">
+					<p class="style-cs-conditions" title="Condition Level">
 						<select class="style-cs-conditions" name="system.Characteristics.{{@key}}.Condition.Current"
 							id="system.Characteristics.{{@key}}.Condition.Current" data-dtype="Number">
 							<option value="0" {{selected this.Condition.Current 0}}>0</option>
@@ -77,7 +77,7 @@
 								for="system.Characteristics.{{@../key}}.Stats.{{@key}}.Buff.Current">{{this.Buff.Name}}</label>
 						</p>
 						<p class="style-cs-buffs">
-							<select class="style-cs-buffs"
+							<select class="style-cs-buffs" title="Buff Level"
 								name="system.Characteristics.{{@../key}}.Stats.{{@key}}.Buff.Current"
 								id="system.Characteristics.{{@../key}}.Stats.{{@key}}.Buff.Current" data-dtype="Number">
 								<option value="0" {{selected this.Buff.Current 0}}>0</option>
@@ -96,7 +96,7 @@
 						<p class="style-cs-conditions">💀 <label
 								for="system.Characteristics.{{@../key}}.Stats.{{@key}}.Condition.Name">{{this.Condition.Name}}</label>
 						</p>
-						<p class="style-cs-conditions"><select class="style-cs-conditions"
+						<p class="style-cs-conditions"><select class="style-cs-conditions" title="Condition Level"
 								name="system.Characteristics.{{@../key}}.Stats.{{@key}}.Condition.Current"
 								id="system.Characteristics.{{@../key}}.Stats.{{@key}}.Condition.Current"
 								data-dtype="Number">
@@ -117,7 +117,7 @@
 				<div class="style-cs-conditions">
 					<p class="style-cs-conditions">💀 <label
 							for="system.Characteristics.{{@../key}}.CoreConditions.{{@key}}">{{@key}}</label></p>
-					<p class="style-cs-conditions"><select class="style-cs-conditions"
+					<p class="style-cs-conditions" title="Condition Level"><select class="style-cs-conditions"
 							name="system.Characteristics.{{@../key}}.CoreConditions.{{@key}}"
 							id="system.Characteristics.{{@../key}}.CoreConditions.{{@key}}" data-dtype="Number">
 							<option value="0" {{selected this 0}}>0</option>
@@ -142,7 +142,7 @@
 			<div class="style-labels-secondary">
 				<span class="style-cs-conditions">💀 <label
 						for="system.physical.speed.Conditions.slowed.value">Slowed</label> <select
-						class="style-cs-conditions" name="system.physical.speed.Conditions.slowed.value"
+						class="style-cs-conditions" title="Condition Level" name="system.physical.speed.Conditions.slowed.value"
 						id="system.physical.speed.Conditions.slowed.value" data-dtype="Number">
 						<option value="0" {{selected system.physical.speed.Conditions.slowed.value 0}}>0
 						</option>
@@ -172,7 +172,7 @@
 				</span>
 				<span class="style-cs-buffs">🛡️ <label
 						for="system.physical.speed.Buffs.accelerated.value">Accelerated</label> <select
-						class="style-cs-buffs" name="system.physical.speed.Buffs.accelerated.value"
+						class="style-cs-buffs" title="Buff Level" name="system.physical.speed.Buffs.accelerated.value"
 						id="system.physical.speed.Buffs.accelerated.value" data-dtype="Number">
 						<option value="0" {{selected system.physical.speed.Buffs.accelerated.value 0}}>0</option>
 						<option value="1" {{selected system.physical.speed.Buffs.accelerated.value 1}}>1</option>
@@ -191,7 +191,7 @@
 			<div class="style-labels-secondary">
 				<span class="style-cs-conditions">💀 <label
 						for="system.physical.weight.Conditions.encumbered.value">Encumbered</label> <select
-						class="style-cs-conditions" name="system.physical.weight.Conditions.encumbered.value"
+						class="style-cs-conditions" title="Condition Level" name="system.physical.weight.Conditions.encumbered.value"
 						id="system.physical.weight.Conditions.encumbered.value" data-dtype="Number">
 						<option value="0" {{selected system.physical.weight.Conditions.encumbered.value 0}}>0
 						</option>
@@ -221,7 +221,7 @@
 				</span>
 				<span class="style-cs-buffs">🛡️ <label
 						for="system.physical.weight.Buffs.lightened.value">Lightened</label> <select
-						class="style-cs-buffs" name="system.physical.weight.Buffs.lightened.value"
+						class="style-cs-buffs" title="Buff Level" name="system.physical.weight.Buffs.lightened.value"
 						id="system.physical.weight.Buffs.lightened.value" data-dtype="Number">
 						<option value="0" {{selected system.physical.weight.Buffs.lightened.value 0}}>0</option>
 						<option value="1" {{selected system.physical.weight.Buffs.lightened.value 1}}>1</option>
@@ -240,7 +240,7 @@
 			<div class="style-labels-secondary">
 				<span class="style-cs-conditions">💀 <label
 						for="system.physical.size.Conditions.shrunken.value">Shrunken</label> <select
-						class="style-cs-conditions" name="system.physical.size.Conditions.shrunken.value"
+						class="style-cs-conditions" title="Condition Level" name="system.physical.size.Conditions.shrunken.value"
 						id="system.physical.size.Conditions.shrunken.value" data-dtype="Number">
 						<option value="0" {{selected system.physical.size.Conditions.shrunken.value 0}}>0
 						</option>
@@ -269,7 +269,7 @@
 				<span class="style-cs-values" title="Size represents how much space a Character (or an Object) can occupy in an area.">📐 Size {{system.physical.size.value}}
 				</span>
 				<span class="style-cs-buffs">🛡️ <label for="system.physical.size.Buff.enlarged.value">Enlarged</label>
-					<select class="style-cs-buffs" name="system.physical.size.Buffs.enlarged.value"
+					<select class="style-cs-buffs" title="Buff Level" name="system.physical.size.Buffs.enlarged.value"
 						id="system.physical.size.Buffs.enlarged.value" data-dtype="Number">
 						<option value="0" {{selected system.physical.size.Buffs.enlarged.value 0}}>0</option>
 						<option value="1" {{selected system.physical.size.Buffs.enlarged.value 1}}>1</option>
@@ -288,7 +288,7 @@
 		</div>
 		<div class="layout-container-small style-container-small">
 			<form>
-				<div title="Resistance is a static number that reduces the total amount of Damage dealt,">Resistances</div>
+				<div title="Resistance is a static number that reduces the total amount of Damage dealt">Resistances</div>
 				<div class="form-group">Cosmic
 					<input name="system.physical.resistances.cosmic.initial" type="number"
 						value="{{system.physical.resistances.cosmic.initial}}" data-dtype="Number" placeholder="0" />


### PR DESCRIPTION
Changed to use actor.uuid instead of actor.id to facilitate both linked and unlinked actors.
MetaInitiative now calls MetaRoll, automatically keeps the result of the latest roll as the initiative result.
Various minor fixes & console logging enhancements